### PR TITLE
Updated HTTPS downloader to work with older Java versions

### DIFF
--- a/brainstorm/src/org/brainstorm/TestClass.java
+++ b/brainstorm/src/org/brainstorm/TestClass.java
@@ -305,8 +305,8 @@ public class TestClass {
     // ===== TEST DOWNLOAD =====
     public static void TestDownload(){
         // Download file
-        // String srcUrl  = "https://neuroimage.usc.edu/brainstorm3_register/getupdate.php?c=UbsM09";
-        String srcUrl  = "https://neuroimage.usc.edu/brainstorm3_register/getupdate.php?t=Infant7w";
+        String srcUrl  = "https://neuroimage.usc.edu/bst/getupdate.php?c=UbsM09";
+        //String srcUrl  = "https://github.com/csn-le/wave_clus/archive/master.zip";
         final BstDownload bstDownload = new BstDownload(srcUrl, "C:\\Users\\francois\\Downloads\\test.zip", "Download test");
         
         bstDownload.download();
@@ -322,7 +322,7 @@ public class TestClass {
         if (bstDownload.getResult() != 1){
             JOptionPane.showMessageDialog(null, "Error downloading file: \n" + bstDownload.getMessage(), "Download file", JOptionPane.WARNING_MESSAGE);
         }else{
-            JOptionPane.showMessageDialog(null, bstDownload.getMessage(), "Download file", JOptionPane.OK_OPTION);
+            JOptionPane.showMessageDialog(null, "File successfully downloaded!", "Download file", JOptionPane.OK_OPTION);
         }
     }
     
@@ -350,11 +350,11 @@ public class TestClass {
                 //TestTableWindow();
                 // TestFileSelector();
                 // TestDialog();
-                // TestDownload();
+                TestDownload();
                 //TestListWindow();
                 // TestCheckListWindow();
                 //TestTreeWindow();
-                TestHotkeyDialog();
+                //TestHotkeyDialog();
                 // TestTreeTableWindow();
                 //CloneControl.probe("C:\\Work\\Dev\\brainstorm_git\\brainstorm3");
                 

--- a/brainstorm/src/org/brainstorm/file/BstDownload.java
+++ b/brainstorm/src/org/brainstorm/file/BstDownload.java
@@ -126,7 +126,7 @@ public class BstDownload {
     
     // Download thread
     public void downloadThread(Proxy proxy){
-        RandomAccessFile file = null;
+        OutputStream file = null;
         InputStream stream = null;
         int downloaded = 0;
         
@@ -156,7 +156,7 @@ public class BstDownload {
             jProgressBar.setMaximum(contentLength);
 
             // Open output file
-            file = new RandomAccessFile(outputFile, "rws");
+            file = new FileOutputStream(outputFile);
             stream = connection.getInputStream();
             isDownloading = true;
 

--- a/brainstorm/src/org/brainstorm/file/BstDownload.java
+++ b/brainstorm/src/org/brainstorm/file/BstDownload.java
@@ -36,9 +36,20 @@ public class BstDownload {
         // ===== COPY ARGUMENTS =====
         // Output filename
         outputFile = file;
+        // Old versions of Matlab default to a weird ICE library URL Handler
+        // that causes HTTPS issues. Force usage of proper Handler if possible.
+        URLStreamHandler handler = null;
+        if (strUrl.toLowerCase().startsWith("https"))
+        {
+            try {
+                handler = new sun.net.www.protocol.https.Handler();
+            } catch (Exception e) {
+                handler = null;
+            }
+        }
         // Input URL
         try{
-            url = new java.net.URL(strUrl);
+            url = new java.net.URL(null, strUrl, handler);
         }
         catch (Exception e){
             jLabel.setText("Error: Invalid URL.");


### PR DESCRIPTION
When I started integrating downloads from GitHub repositories in Brainstorm, I ran into the problem of the fact that GitHub forces downloads through a TLS 1.2 connection, which is only supported by Java 1.7+. So I disabled HTTPS downloads for older Java versions.

Now that NeuroImage.usc.edu is under HTTPS as well, this is obviously an issue for most other downloads as well under Java 1.6. I therefore implemented a non-TLS connection for non-GitHub Java 1.6 HTTPS downloads. I however ran into another problem of very old versions of Java 1.6.0 (which ships with Matlab 2008a and probably others) rejecting NeuroImage's SSL certificate... So I went with the proposed solution [here](https://stackoverflow.com/questions/23775155/pkix-path-does-not-chain-with-any-of-the-trust-anchors-error-in-windows-environm) and added a "trust all certificates" option to our SSL download connection for Java 1.6.

This is obviously completely insecure but I think as long as we're in control of what URLs are added in the public Brainstorm repo it shouldn't be an issue (also keep in mind that this is only for old supported  Matlab versions with Java 1.6).

In my early tests it's working fine for our oldest and newest supported Matlab and Java versions. If you're fine with the solution I'll go ahead and do more extensive tests.